### PR TITLE
Add Chrome Web Store link for Adhan-ce extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
   IoT orchestration for automated prayer-time notifications via Raspberry Pi + Android TV (ADB)
 - **[Monthly Phone Bill Split & Autopay Automation](https://github.com/bilalahamad0/tmo)**<br>
   event-driven system automating T-Mobile family-plan bill parsing and cost splits
-- **[Adhan Caster Pro: Chrome Extension](https://github.com/bilalahamad0/adhan-ce)**<br>
+- **[Adhan Caster Pro: Chrome Extension](https://github.com/bilalahamad0/adhan-ce)** **[\[Chrome Web Store ↗\]](https://chromewebstore.google.com/detail/jfjknglldcdminelckmmfdbnlikiogia?utm_source=item-share-cb)**<br>
   Manifest V3 extension that auto-pauses media across all tabs at prayer times
 - **[Portfolio: bilalahamad.com](https://github.com/bilalahamad0/profile)** **[\[Live Site ↗\]](https://bilalahamad.com)**<br>
   Next.js portfolio with glassmorphism design and live GitHub integration


### PR DESCRIPTION
## Summary
- Adhan-ce is now published on the Chrome Web Store, so the README's project entry now links straight to the listing for one-click installs.
- Uses the existing `[Live Dashboard ↗]` link pattern from the other projects to keep the section visually consistent.

## Test plan
- [ ] View the rendered README on GitHub and confirm the new **[Chrome Web Store ↗]** link sits next to the repo link on the Adhan Caster Pro row.
- [ ] Click the link and confirm it lands on the published listing (`chromewebstore.google.com/detail/jfjknglldcdminelckmmfdbnlikiogia`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)